### PR TITLE
Sprint 20211213 01

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.dat
 *.pyc
 log.txt
+.project
+.*
 
 # exclude directories completely
 Images

--- a/README.md
+++ b/README.md
@@ -2,3 +2,33 @@
  oslib mql5
  
  Projeto abriga Expert Advisors e Indicadores que funcionam na plataforma Metatrader 5.
+
+
+## Como configurar o projeto.
+1. **Compilação**: execute este comando na pasta "include" do terminal.
+   
+   `mklink /D oslib <PASTA_OSLIB-MQL>\oslib`
+    
+    
+    Por exemplo, supondo que eu tenha colocado a pasta `oslib-mql` em `c:\github\oblib-mql`, o comando seria 
+    
+    `mklink /D oslib c:\github\oblib-mql\oslib`
+
+2. **Experts**: execute este comando na pasta "Experts" do terminal.
+   
+   `mklink /D oslib-ose <PASTA_OSLIB-MQL>\oslib\ose`
+
+3. **Indicadores**: execute este comando na pasta "Indicators" do terminal.
+   
+   `mklink /D oslib-osi <PASTA_OSLIB-MQL>\oslib\osi`
+
+4. **Services**: execute este comando na pasta "Services" do terminal.
+   
+   `mklink /D oslib-svc <PASTA_OSLIB-MQL>\oslib\svc`
+
+5. **Scripts**: execute estes comandos na pasta "Scripts" do terminal.
+   
+   `mklink /D oslib-scr <PASTA_OSLIB-MQL>\oslib\scr`
+   
+   `mklink /D oslib-tst <PASTA_OSLIB-MQL>\oslib\tst`
+

--- a/osc/data/osc-cusum.mqh
+++ b/osc/data/osc-cusum.mqh
@@ -9,7 +9,7 @@
 //+---------------------------------------------------------------------+
 //| Implementacoes CUSUM - Cumulative Sum.                              |
 //+---------------------------------------------------------------------+
-#property description "Vetor circular baseado em filas visando rapido calculo de medias."
+#property description "Soma cumulativa."
 
 #include <Object.mqh>
 #include <Generic\Queue.mqh>

--- a/osc/data/osc_db.mqh
+++ b/osc/data/osc_db.mqh
@@ -288,7 +288,7 @@ private:
 
     bool create_table_acum_feature(){
     
-    //--- check if the table exists 
+    //--- check if the table exists 1
        if(!DatabaseTableExists(m_db, "acum_feature")){
           //--- create the table 
           if(!DatabaseExecute(m_db, "CREATE TABLE acum_feature(" 

--- a/osc/est/C00021Pairs.mqh
+++ b/osc/est/C00021Pairs.mqh
@@ -48,7 +48,7 @@ public:
     int    getQtdSegMedia() { return m_qtd_seg_media; }
 
     // inicializacao antes de comecar a acumular.
-    // deve infirmar a quantidade de segundos usados do calculo da media dos spreads.
+    // deve informar a quantidade de segundos usados do calculo da media dos spreads.
     // se nao informar, calcularah a media da ultima hora de spreads.
     void initialize(int qtdSegMedia=60*60){ 
         setQtdSegMedia(qtdSegMedia);

--- a/osc/est/CStat.mqh
+++ b/osc/est/CStat.mqh
@@ -190,6 +190,7 @@ class CStat{
         }
 
         if(sx2==0){msg=":-( somatorio de x2 eh zero. Nao eh possivel estimar a regressao";
+                   Print(msg);
                    Print("Eixo Y"); ArrayPrint(y);
                    Print("Eixo X"); ArrayPrint(x);
                    return false;}
@@ -223,6 +224,7 @@ class CStat{
         }
 
         if(sqt==0){msg=":-( SQT eh zero. Nao eh possivel calcular r2";
+                   Print(msg);
                    Print("Eixo Y"); ArrayPrint(y);
                    Print("Eixo X"); ArrayPrint(x);
                    return false;}

--- a/osc/est/c00101cusum.mqh
+++ b/osc/est/c00101cusum.mqh
@@ -1,0 +1,109 @@
+﻿//+------------------------------------------------------------------+
+//|                                                  c00101cusum.mqh |
+//|                                                           marcoc |
+//|                             https://www.mql5.com/pt/users/marcoc |
+//+------------------------------------------------------------------+
+#property copyright "marcoc"
+#property link      "https://www.mql5.com/pt/users/marcoc"
+#property version   "1.00"
+//+---------------------------------------------------------------------+
+//| Implementacoes CUSUM - Cumulative Sum.                              |
+//+---------------------------------------------------------------------+
+#property description "Soma cumulativa."
+
+#include <Object.mqh>
+#include <oslib/osc/est/CStat.mqh>
+#include <oslib/osc/osc-media.mqh>
+
+
+class c00101cusum : public CObject{
+private:
+    double    m_c_mais , m_c_mais_ant ; // acumulacao acima da media
+    double    m_c_menos, m_c_menos_ant; // acumulacao abaixo da media
+    double    m_k                     ; // treshould; quantidade de desvios padrao alem da qual devera acumular X;
+    double    m_h                     ; // strike   ; quantidade de desvios padrao alem do qual deverah disparar o alerta;
+  //int       m_intervalo_acum        ; // intervalo de acumulacao em segundos;
+    osc_media m_vet_x                 ; // vetor de ocorrencias para as quais a soma acumulada estah sendo calculada;
+    osc_media m_vet_cmais             ; // vetor de ocorrencias de C+; usado pra saber a tendencia de C+;
+    osc_media m_vet_cmenos            ; // vetor de ocorrencias de C-; usado pra saber a tendencia de C-
+    double    m_dp                    ; // desvio padrao das ocorrencias de x.
+
+
+    void calc_cusum(const double xi){
+    
+       // definindo o desvio padrao do vetor de ocorrencias e usando em seguida para determinar o treshould (K)...
+       m_dp     = sqrt( m_vet_x.getVar() );
+       double K = m_k * m_dp;   // treshould em unidades de desvio padrao.
+    
+        // acumulando C+ e C- ...
+        m_c_mais  = MathMax(0,  xi - ( m_vet_x.getMed() + K ) + m_c_mais_ant  );
+        m_c_menos = MathMax(0, -xi + ( m_vet_x.getMed() - K ) + m_c_menos_ant );
+        
+        // salvando para uso no proximo calculo...
+        m_c_mais_ant  = m_c_mais ;
+        m_c_menos_ant = m_c_menos;
+
+        // adicionando  C+ e C- aos vetores. serve para calcular a tendencia de C+ e C- ...
+        m_vet_cmais .add(m_c_mais );
+        m_vet_cmenos.add(m_c_menos);
+        
+        // calculando a direcao da tendencia de C+ e C- ...
+        m_vet_cmais .regLinFit();
+        m_vet_cmenos.regLinFit();
+    }
+
+protected:
+public:
+    c00101cusum(void): m_c_mais       (0),
+                       m_c_mais_ant   (0),
+                       m_c_menos      (0),
+                       m_c_menos_ant  (0){}
+
+    //
+    // Inicializa as variaveis e o vetor para o calculo da soma acumulada;
+    //
+    //double    k                     treshould; quantidade de desvios padrao alem da qual devera acumular X;
+    //double    h                     strike   ; quantidade de desvios padrao alem do qual deverah disparar o alerta;
+    //int       size_hist             tamanho do historico usado para calcular a media;
+    //int       intervalo_acum        intervalo de acumulacao em segundos;
+    //
+    void initialize(double k=1, double h=5, int size_hist=72, int intervalo_acum=0){
+    	m_k         = k;
+        m_h         = h;
+        m_vet_x     .initialize(size_hist,intervalo_acum);
+        m_vet_cmais .initialize(size_hist,intervalo_acum);
+        m_vet_cmenos.initialize(size_hist,intervalo_acum);
+        
+    }
+
+    // adiciona uma ocorrencia (xi)...
+    void add(double xi){
+        
+        // adicionando ao vetor de ocorrencias e jah deixa a variancia calculada (segundo parametro igual a true)...
+        m_vet_x.add(xi,true);
+
+        // calculando C+ e C- ...
+        calc_cusum(xi);
+    }
+
+    // adiciona uma ocorrencia (xi) com timeframe. Como usa timeframe, deve informar a hora da ocorrencia (ti).
+    //Se a adicao for antes de completar o timeframe, serah desprezada.
+    void add(double xi, const datetime ti){
+        
+        // adicionando ao vetor de ocorrencias e jah deixa a variancia calculada (terceiro parametro igual a true)...
+        // se jah adicionaou no timeframe parametrizado, nao adiciona e retorna false. Neste caso, nao acumulamos.
+        if( !m_vet_x.add(xi,ti,true) ){ return;}
+        
+        // calculando C+ e C- ...
+        calc_cusum(xi);
+    }
+    
+    // resultado da ultima acumulacao...
+    double getCmais (){return m_c_mais ;}
+    double getCmenos(){return m_c_menos;}
+    
+    // coeficientes lineares dos vetores de acumulacao. servem para saber a tendencia do C+ e C- ...
+    double get_slope_cmais (){ return m_vet_cmais .regLinGetSlope(); }
+    double get_slope_cmenos(){ return m_vet_cmenos.regLinGetSlope(); }
+
+};

--- a/osc/osc-media.mqh
+++ b/osc/osc-media.mqh
@@ -1,13 +1,13 @@
 ﻿//+------------------------------------------------------------------+
 //|                                                    osc-media.mqh |
-//|                        Copyright 2019, MetaQuotes Software Corp. |
+//|                             Copyright 2020, Oficina de Software. |
 //|                                             https://www.mql5.com |
 //+------------------------------------------------------------------+
 #property copyright "2020, Oficina de Software."
 #property link      "http://www.os.net"
 
 #include <oslib/osc/est/CStat.mqh>
-#include <Math\Stat\Math.mqh>
+#include <Math/Stat/Math.mqh>
 
 // calculo de media simples baseada em quantidade fixa de elementos. A medida que o vetor de valores enche, despreza o valor mais antigo,
 // adiciona o mais novo e reclacula a media.
@@ -59,7 +59,7 @@ public:
     // Adiciona um item a media, retira o mais antigo (se for maior que o tamanho do vetor de medias) e retorna o valor da media.
     // Se nao tiver passado o time_frame informado na inicializacao, nao adiciona e retorna falso.
     //----------------------------------------------------------------------------------------------------
-    bool add(const double val, datetime time){
+    bool add(const double val, datetime time, bool calc_var=false){
          //Print("m_len:",m_len," ind:",m_ind," time:",time," val:",val," m_mean:",m_mean);
          // se nao passou o time_frame minimo para acumular, nao faz nada e retorna falso.
          if( (time - m_dt_ult_add) < m_tf ) return false;
@@ -70,13 +70,15 @@ public:
          // adicionando...
          add(val);
          
+         if(calc_var){ calcVar(); }
+         
          return true;
     }
     
     //----------------------------------------------------------------------------------------------------
     // Adiciona um item a media, retira o mais antigo (se for maior que o tamanho do vetor de medias) e retorna o valor da media.
     //----------------------------------------------------------------------------------------------------
-    double add(const double val){
+    double add(const double val, bool calc_var=false){
     
         if( m_len_calc < m_len ) m_len_calc++;
          
@@ -86,7 +88,11 @@ public:
          
         if( ++m_ind == m_len_calc ){ m_ind=0; }   // atualizando o indice
          
-        return m_mean = ( m_tot/(double)m_len_calc );       
+        m_mean = ( m_tot/(double)m_len_calc );       
+        
+        if(calc_var){ calcVar(); }
+
+        return m_mean;
     }
 
     //----------------------------------------------------------------------------------------------------

--- a/ose/ose-p7-004-001-formador-de-mercado.mq5
+++ b/ose/ose-p7-004-001-formador-de-mercado.mq5
@@ -459,7 +459,7 @@ int OnInit(){
 
     m_posicao.Select( m_symb_str ); // selecao da posicao por simbolo.
 
-    m_canal.inicializar(m_tick_size,EA_TAMANHO_CANAL, EA_PORC_REGIAO_OPERACIONAL_CANAL);
+    m_canal.inicializar(m_symb,EA_TAMANHO_CANAL, EA_PORC_REGIAO_OPERACIONAL_CANAL);
     m_canal.setShowCanalPrecos(EA_SHOW_CANAL_PRECOS);
     m_canal.setRegiaoBuySellUsaCanalDia(EA_CANAL_DIARIO);
     

--- a/ose/ose-p7-004-003-02-ns.mq5
+++ b/ose/ose-p7-004-003-02-ns.mq5
@@ -2173,8 +2173,8 @@ bool fecharPosicaoHFTCusumSimples(){
 
 //void abrirPosicaoHFTFormadorDeMercado    (){     abrirPosicaoHFTFormadorDeMercadoCusumV3();}
 //void gerenciarPosicaoHFTFormadorDeMercado(){ gerenciarPosicaoHFTFormadorDeMercadoCusumV4();}
-//void abrirPosicaoHFTFormadorDeMercado    (){     abrirPosicaoHFTFormadorDeMercadoSimplesNaMediaDoTrade();}
-  void abrirPosicaoHFTFormadorDeMercado    (){     abrirPosicaoHFTFormadorDeMercadoSimplesNaMediaDoBook();}
+  void abrirPosicaoHFTFormadorDeMercado    (){     abrirPosicaoHFTFormadorDeMercadoSimplesNaMediaDoTrade();}
+//void abrirPosicaoHFTFormadorDeMercado    (){     abrirPosicaoHFTFormadorDeMercadoSimplesNaMediaDoBook();}
 //void gerenciarPosicaoHFTFormadorDeMercado(){     abrirPosicaoHFTFormadorDeMercadoV5     ();}
 bool fecharPosicaoHFTCusum               (){ return fecharPosicaoHFTCusumSimples          ();}
 bool stopGainParcial                     (){ return stopGainParcialSimples                ();}

--- a/osi/osi-03-08-01-fluxo-agressoes-book.mq5
+++ b/osi/osi-03-08-01-fluxo-agressoes-book.mq5
@@ -13,7 +13,7 @@
 #include <oslib\os-lib.mq5>
 #include <oslib\osc\est\osc-estatistic3.mqh>
 #include <oslib\osc-tick-util.mqh>
-#include <oslib\osc\osc_db.mqh>
+#include <oslib\osc\data\osc_db.mqh>
 
 input bool   DEBUG                   = false ; // se true, grava informacoes de debug no log.
 input bool   GERAR_VOLUME            = false ; // se true, gera volume baseado nos ticks. Usa em papeis que nao informam volume, tais como o DJ30.

--- a/osres/install-os-2.bat
+++ b/osres/install-os-2.bat
@@ -31,126 +31,73 @@ rem comando para buscar arquivos binarios que deveria ser utf8 (execute no shell
 rem  find $PWD -type f | grep -E 'py|mq5|mqh'  | xargs file -i * | grep -v -E 'utf-8|ascii|directo|pyc'
 rem
 
-set TERMINAL_CLEAR=3BA9A43D10A400EE3A5C25C340D7DDC6
-set TERMINAL_CLDES=F2736DC84E60965E8E88F26409B862DA
-set TERMINAL_MODAL=8204B85248FF5705904F2EEC17F50E0C
-set TERMINAL_DESEN=1359089FFD8DE572A105C49A845B99B2
-set TERMINAL_MODES=43E4454D6B6E5524BFF7C681126AD41E
-set TERMINAL_ACDES=FE0E65DDB0B7B40DE125080872C34D61
-
-
-
-rem cd C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Projects\projetcts\os-ea
-
-rem copy ea*.ex5 ..\..\..\Experts\os\
-rem copy ea*.ex5 ..\..\..\..\..\%TERMINAL_CLEAR%\MQL5\Experts\os\
-rem copy ea*.ex5 ..\..\..\..\..\%TERMINAL_CLDES%\MQL5\Experts\os\
-rem copy ea*.ex5 ..\..\..\..\..\%TERMINAL_MODAL%\MQL5\Experts\os\
-rem copy ea*.ex5 ..\..\..\..\..\%TERMINAL_MODES%\MQL5\Experts\os\
-rem copy ea*.ex5 ..\..\..\..\..\%TERMINAL_ACDES%\MQL5\Experts\os\
-
-rem copy ..\..\..\Indicators\os\osi-teste-01-03-feira\*.ex5 ..\..\..\..\..\%TERMINAL_CLEAR%\MQL5\Indicators\os\
-rem copy ..\..\..\Indicators\os\osi-teste-01-03-feira\*.ex5 ..\..\..\..\..\%TERMINAL_CLDES%\MQL5\Indicators\os\
-rem copy ..\..\..\Indicators\os\osi-teste-01-03-feira\*.ex5 ..\..\..\..\..\%TERMINAL_MODAL%\MQL5\Indicators\os\
-rem copy ..\..\..\Indicators\os\osi-teste-01-03-feira\*.ex5 ..\..\..\..\..\%TERMINAL_MODES%\MQL5\Indicators\os\
-rem copy ..\..\..\Indicators\os\osi-teste-01-03-feira\*.ex5 ..\..\..\..\..\%TERMINAL_ACDES%\MQL5\Indicators\os\
+set TERMINAL_CLEAR=D:\programs\metatrader\clear
+set TERMINAL_CLDES=D:\programs\metatrader\clear-desen
+set TERMINAL_MODAL=D:\programs\metatrader\modal
+set TERMINAL_DESEN=D:\programs\metatrader\desen
+set TERMINAL_MODES=D:\programs\metatrader\modal-desen
 
 @echo on
 
+call :copy-ind
+call :copy-exp
+call :copy-scr
+call :copy-svc
+goto :EOF
+
 rem copiando indicadores
-cd C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Indicators
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_CLEAR%\MQL5\Indicators\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_CLDES%\MQL5\Indicators\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_MODAL%\MQL5\Indicators\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_MODES%\MQL5\Indicators\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_ACDES%\MQL5\Indicators\"
+:copy-ind
+cd %TERMINAL_DESEN%\MQL5\Indicators
+xcopy /s /d /y "oslib-osi" "%TERMINAL_CLEAR%\MQL5\Indicators\"
+xcopy /s /d /y "oslib-osi" "%TERMINAL_CLDES%\MQL5\Indicators\"
+xcopy /s /d /y "oslib-osi" "%TERMINAL_MODAL%\MQL5\Indicators\"
+xcopy /s /d /y "oslib-osi" "%TERMINAL_MODES%\MQL5\Indicators\"
+
 
 rem copiando experts
-cd C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Experts
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_CLEAR%\MQL5\Experts\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_CLDES%\MQL5\Experts\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_MODAL%\MQL5\Experts\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_MODES%\MQL5\Experts\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_ACDES%\MQL5\Experts\"
+:copy-exp
+cd %TERMINAL_DESEN%\MQL5\Experts
+xcopy /s /d /y "oslib-ose" "%TERMINAL_CLEAR%\MQL5\Experts\"
+xcopy /s /d /y "oslib-ose" "%TERMINAL_CLDES%\MQL5\Experts\"
+xcopy /s /d /y "oslib-ose" "%TERMINAL_MODAL%\MQL5\Experts\"
+xcopy /s /d /y "oslib-ose" "%TERMINAL_MODES%\MQL5\Experts\"
 
 rem copiando scripts
-cd C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Scripts
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_CLEAR%\MQL5\Scripts\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_CLDES%\MQL5\Scripts\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_MODAL%\MQL5\Scripts\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_MODES%\MQL5\Scripts\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_ACDES%\MQL5\Scripts\"
+:copy-scr
+cd %TERMINAL_DESEN%\MQL5\Scripts
+xcopy /s /d /y "oslib-scr" "%TERMINAL_CLEAR%\MQL5\Scripts\"
+xcopy /s /d /y "oslib-scr" "%TERMINAL_CLDES%\MQL5\Scripts\"
+xcopy /s /d /y "oslib-scr" "%TERMINAL_MODAL%\MQL5\Scripts\"
+xcopy /s /d /y "oslib-scr" "%TERMINAL_MODES%\MQL5\Scripts\"
+
+xcopy /s /d /y "oslib-tst" "%TERMINAL_CLEAR%\MQL5\Scripts\"
+xcopy /s /d /y "oslib-tst" "%TERMINAL_CLDES%\MQL5\Scripts\"
+xcopy /s /d /y "oslib-tst" "%TERMINAL_MODAL%\MQL5\Scripts\"
+xcopy /s /d /y "oslib-tst" "%TERMINAL_MODES%\MQL5\Scripts\"
 
 rem copiando servicos
-cd C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Services
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_CLEAR%\MQL5\Services\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_CLDES%\MQL5\Services\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_MODAL%\MQL5\Services\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_MODES%\MQL5\Services\"
-xcopy /s /d /y "Shared Projects" "..\..\..\%TERMINAL_ACDES%\MQL5\Services\"
-
-
-rem cd C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Indicators\Shared Projects
-rem copy .\oslib\osi\*.ex5 "..\..\..\..\%TERMINAL_CLEAR%\MQL5\Indicators\Shared Projects\oslib\osi\"
-rem copy .\oslib\osi\*.ex5 "..\..\..\..\%TERMINAL_CLDES%\MQL5\Indicators\Shared Projects\oslib\osi\"
-rem copy .\oslib\osi\*.ex5 "..\..\..\..\%TERMINAL_MODAL%\MQL5\Indicators\Shared Projects\oslib\osi\"
-rem copy .\oslib\osi\*.ex5 "..\..\..\..\%TERMINAL_MODES%\MQL5\Indicators\Shared Projects\oslib\osi\"
-rem copy .\oslib\osi\*.ex5 "..\..\..\..\%TERMINAL_ACDES%\MQL5\Indicators\Shared Projects\oslib\osi\"
-
-rem cd C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Indicators
-rem copy .\Market\*.ex5 "..\..\%TERMINAL_CLEAR%\MQL5\Indicators\Market\"
-rem copy .\Market\*.ex5 "..\..\%TERMINAL_CLDES%\MQL5\Indicators\Market\"
-rem copy .\Market\*.ex5 "..\..\%TERMINAL_MODAL%\MQL5\Indicators\Market\"
-rem copy .\Market\*.ex5 "..\..\%TERMINAL_MODES%\MQL5\Indicators\Market\"
-rem copy .\Market\*.ex5 "..\..\%TERMINAL_ACDES%\MQL5\Indicators\Market\"
-rem 
-rem copy tst "..\..\%TERMINAL_CLEAR%\MQL5\Indicators\"
-rem copy tst "..\..\%TERMINAL_CLDES%\MQL5\Indicators\"
-rem copy tst "..\..\%TERMINAL_MODAL%\MQL5\Indicators\"
-rem copy tst "..\..\%TERMINAL_MODES%\MQL5\Indicators\"
-rem copy tst "..\..\%TERMINAL_ACDES%\MQL5\Indicators\"
-
-rem C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\1359089FFD8DE572A105C49A845B99B2\MQL5\Indicators>copy tst "..\..\3BA9A43D10A400EE3A5C25C340D7DDC6\MQL5\Indicators\"
-
-rem cd C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Experts\\Shared Projects
-rem copy .\oslib\ose\*.ex5 "..\..\..\..\%TERMINAL_CLEAR%\MQL5\Experts\Shared Projects\oslib\ose\"
-rem copy .\oslib\ose\*.ex5 "..\..\..\..\%TERMINAL_CLDES%\MQL5\Experts\Shared Projects\oslib\ose\"
-rem copy .\oslib\ose\*.ex5 "..\..\..\..\%TERMINAL_MODAL%\MQL5\Experts\Shared Projects\oslib\ose\"
-rem copy .\oslib\ose\*.ex5 "..\..\..\..\%TERMINAL_MODES%\MQL5\Experts\Shared Projects\oslib\ose\"
-rem copy .\oslib\ose\*.ex5 "..\..\..\..\%TERMINAL_ACDES%\MQL5\Experts\Shared Projects\oslib\ose\"
-rem 
-rem cd C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Experts
-rem copy "Shared Projects" "..\..\..\%TERMINAL_CLEAR%\MQL5\Experts\"
-
-rem copiando scripts...
-rem cd C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Scripts\\Shared Projects
-rem copy .\oslib\scr\*.ex5 "..\..\..\..\%TERMINAL_CLEAR%\MQL5\Scripts\Shared Projects\oslib\scr\"
-rem copy .\oslib\scr\*.ex5 "..\..\..\..\%TERMINAL_CLDES%\MQL5\Scripts\Shared Projects\oslib\scr\"
-rem copy .\oslib\scr\*.ex5 "..\..\..\..\%TERMINAL_MODAL%\MQL5\Scripts\Shared Projects\oslib\scr\"
-rem copy .\oslib\scr\*.ex5 "..\..\..\..\%TERMINAL_MODES%\MQL5\Scripts\Shared Projects\oslib\scr\"
-rem copy .\oslib\scr\*.ex5 "..\..\..\..\%TERMINAL_ACDES%\MQL5\Scripts\Shared Projects\oslib\scr\"
-rem 
-rem rem copiando servicos...
-rem cd C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Services\\Shared Projects
-rem copy .\oslib\svc\*.ex5 "..\..\..\..\%TERMINAL_CLEAR%\MQL5\Services\Shared Projects\oslib\svc\"
-rem copy .\oslib\svc\*.ex5 "..\..\..\..\%TERMINAL_CLDES%\MQL5\Services\Shared Projects\oslib\svc\"
-rem copy .\oslib\svc\*.ex5 "..\..\..\..\%TERMINAL_MODAL%\MQL5\Services\Shared Projects\oslib\svc\"
-rem copy .\oslib\svc\*.ex5 "..\..\..\..\%TERMINAL_MODES%\MQL5\Services\Shared Projects\oslib\svc\"
-rem copy .\oslib\svc\*.ex5 "..\..\..\..\%TERMINAL_ACDES%\MQL5\Services\Shared Projects\oslib\svc\"
+:copy-svc
+cd %TERMINAL_DESEN%\MQL5\Services
+xcopy /s /d /y "oslib-svc" "%TERMINAL_CLEAR%\MQL5\Services\"
+xcopy /s /d /y "oslib-svc" "%TERMINAL_CLDES%\MQL5\Services\"
+xcopy /s /d /y "oslib-svc" "%TERMINAL_MODAL%\MQL5\Services\"
+xcopy /s /d /y "oslib-svc" "%TERMINAL_MODES%\MQL5\Services\"
 
 rem copiando templates...
-xcopy /d /y C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Profiles\Templates\my*.tpl C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_CLEAR%\MQL5\Profiles\Templates
-xcopy /d /y C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Profiles\Templates\my*.tpl C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_CLDES%\MQL5\Profiles\Templates
-xcopy /d /y C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Profiles\Templates\my*.tpl C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_MODAL%\MQL5\Profiles\Templates
-xcopy /d /y C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Profiles\Templates\my*.tpl C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_MODES%\MQL5\Profiles\Templates
-xcopy /d /y C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Profiles\Templates\my*.tpl C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_ACDES%\MQL5\Profiles\Templates
+:copy-templates
+xcopy /d /y %TERMINAL_DESEN%\MQL5\Profiles\Templates\my*.tpl %TERMINAL_CLEAR%\MQL5\Profiles\Templates
+xcopy /d /y %TERMINAL_DESEN%\MQL5\Profiles\Templates\my*.tpl %TERMINAL_CLDES%\MQL5\Profiles\Templates
+xcopy /d /y %TERMINAL_DESEN%\MQL5\Profiles\Templates\my*.tpl %TERMINAL_MODAL%\MQL5\Profiles\Templates
+xcopy /d /y %TERMINAL_DESEN%\MQL5\Profiles\Templates\my*.tpl %TERMINAL_MODES%\MQL5\Profiles\Templates
 
 rem copiando configuracoes de EA...
-xcopy /d /y C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Presets\*.set C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_CLEAR%\MQL5\Presets
-xcopy /d /y C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Presets\*.set C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_CLDES%\MQL5\Presets
-xcopy /d /y C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Presets\*.set C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_MODAL%\MQL5\Presets
-xcopy /d /y C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Presets\*.set C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_MODES%\MQL5\Presets
-xcopy /d /y C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\Presets\*.set C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_ACDES%\MQL5\Presets
+:copy-ea-config
+xcopy /d /y %TERMINAL_DESEN%\MQL5\Presets\*.set %TERMINAL_CLEAR%\MQL5\Presets
+xcopy /d /y %TERMINAL_DESEN%\MQL5\Presets\*.set %TERMINAL_CLDES%\MQL5\Presets
+xcopy /d /y %TERMINAL_DESEN%\MQL5\Presets\*.set %TERMINAL_MODAL%\MQL5\Presets
+xcopy /d /y %TERMINAL_DESEN%\MQL5\Presets\*.set %TERMINAL_MODES%\MQL5\Presets
+xcopy /d /y %TERMINAL_DESEN%\MQL5\Presets\*.set %TERMINAL_ACDES%\MQL5\Presets
 
-cd C:\Users\Usuario\AppData\Roaming\MetaQuotes\Terminal\%TERMINAL_DESEN%\MQL5\\Shared Projects\oslib\osres
+cd %TERMINAL_DESEN%\MQL5\\Shared Projects\oslib\osres
 
+:EOF


### PR DESCRIPTION
Sprint 20211213 01, composta por:

*Indicador osi-03-18-02-cusum: melhoria na impressão dos valores de strike.

*Expert ose-p7-004-003-02-ns: passa a usar a estratéggia de formador de mercado baseada ma média do Trade.

*Expert ose-p7-004-001-formador-de-mercado: método abrirPosicaoHFTPrioridadeNoBook passa a usar preencherOrdensLimitadasDeVendaAcimaComLag e preencherOrdensLimitadasDeCompraAbaixoComLag, que mantem as ordens de entrada mais afastadas do preço atual.

*Classe c00101cusum: nova classe para registro de somas cumulativas. Pretende ser uma melhoria da classe osc_cusum.

*Classe CStat: melhoria na mensagem de erro ao clacular regressão linear.

*Classe osc_vetor_circular2: novo parâmetro retMin no método add, indicando a diferença mínima entre preços pra considerar que ouve um retorno diferente de zero.

*Classe osc_media: novo parâmetro no método add, indicando se deve recalcular a variância assim que recalcula a média.

*Desprezar arquivos ocultos.